### PR TITLE
609 connection params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docker/.builder/**
 connectionPF.pf
 resources/oe/results.xml
 target/**
+pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,22 +268,34 @@ export async function activate(context: vscode.ExtensionContext) {
         );
     }
 
+    const groupListProvider = new GroupListProvider(
+        context
+    );
+
     const tablesListProvider = new TablesListProvider(
         fieldsProvider,
         indexesProvider,
         context,
+        groupListProvider
     );
 
     const favoritesProvider = new FavoritesProvider(
         fieldsProvider,
         indexesProvider,
         context,
+        groupListProvider
     );
 
     const customViewsProvider = new CustomViewProvider(
         fieldsProvider,
         indexesProvider,
         context,
+        groupListProvider
+    );
+    groupListProvider.setProviders(
+        tablesListProvider,
+        favoritesProvider,
+        customViewsProvider
     );
 
     const customViews = vscode.window.createTreeView(
@@ -311,25 +323,18 @@ export async function activate(context: vscode.ExtensionContext) {
     fieldsProvider.tableListProvider = tablesListProvider;
     indexesProvider.tableListProvider = tablesListProvider;
 
-    const groupListProvider = new GroupListProvider(
-        context,
-        tablesListProvider,
-        favoritesProvider,
-        customViewsProvider
-    );
     const groups = vscode.window.createTreeView(
         `${Constants.globalExtensionKey}-databases`,
         { treeDataProvider: groupListProvider, canSelectMany: true },
+    );
+    groups.onDidChangeSelection((e) =>
+        groupListProvider.onDidChangeSelection(e),
     );
 
     const connectionUpdater = new DbConnectionUpdater();
     connectionUpdater.updateConnectionStatusesWithRefreshCallback(
         context,
         groupListProvider,
-    );
-
-    groups.onDidChangeSelection((e) =>
-        groupListProvider.onDidChangeSelection(e),
     );
 
     /**
@@ -405,15 +410,12 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!cachedQueryEditor) {
             switch (node.source) {
                 case TableNodeSourceEnum.Tables:
-                    tablesListProvider.selectDbConfig(node);
                     tablesListProvider.displayData(node, false);
                     break;
                 case TableNodeSourceEnum.Favorites:
-                    favoritesProvider.selectDbConfig(node);
                     favoritesProvider.displayData(node, false);
                     break;
                 case TableNodeSourceEnum.Custom:
-                    customViewsProvider.selectDbConfig(node);
                     customViewsProvider.displayData(node, false);
                     break;
             }
@@ -427,7 +429,7 @@ export async function activate(context: vscode.ExtensionContext) {
             `${Constants.globalExtensionKey}.saveCustomView`,
             (node: CustomViewNode) => {
                 customViewsProvider.saveCustomView(node);
-                customViewsProvider.refresh(undefined);
+                customViewsProvider.refresh();
             },
         ),
     );
@@ -437,7 +439,7 @@ export async function activate(context: vscode.ExtensionContext) {
             `${Constants.globalExtensionKey}.removeCustomView`,
             (node: CustomViewNode) => {
                 customViewsProvider.removeCustomViews(node);
-                customViewsProvider.refresh(undefined);
+                customViewsProvider.refresh();
             },
         ),
     );
@@ -447,7 +449,7 @@ export async function activate(context: vscode.ExtensionContext) {
             `${Constants.globalExtensionKey}.addFavourite`,
             (node: TableNode) => {
                 favoritesProvider.addTableToFavorites(node);
-                favoritesProvider.refresh(undefined);
+                favoritesProvider.refresh();
             },
         ),
     );
@@ -457,7 +459,7 @@ export async function activate(context: vscode.ExtensionContext) {
             `${Constants.globalExtensionKey}.removeFavourite`,
             (node: TableNode) => {
                 favoritesProvider.removeTableFromFavorites(node);
-                favoritesProvider.refresh(undefined);
+                favoritesProvider.refresh();
             },
         ),
     );
@@ -486,7 +488,6 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             `${Constants.globalExtensionKey}.query`,
             (node: TableNode) => {
-                tablesListProvider.selectDbConfig(node);
                 loadQueryEditor(node, true);
             },
         ),
@@ -496,7 +497,6 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             `${Constants.globalExtensionKey}.queryFavorite`,
             (node: TableNode) => {
-                favoritesProvider.selectDbConfig(node);
                 loadQueryEditor(node, true);
             },
         ),
@@ -506,7 +506,6 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             `${Constants.globalExtensionKey}.queryCustomView`,
             (node: CustomViewNode) => {
-                customViewsProvider.selectDbConfig(node);
                 loadQueryEditor(node);
                 loadCustomView(node);
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,8 +171,8 @@ export async function activate(context: vscode.ExtensionContext) {
         )
             ? oeRuntimes.find((runtime) => runtime.name === oejRuntimeName)
             : oeRuntimes.find(
-                  (runtime) => runtime.name === defaultRuntimeName,
-              ) || oeRuntimes[0];
+                (runtime) => runtime.name === defaultRuntimeName,
+            ) || oeRuntimes[0];
     } else {
         vscode.window.showWarningMessage(
             'No OpenEdge runtime configured on this machine.',
@@ -311,7 +311,12 @@ export async function activate(context: vscode.ExtensionContext) {
     fieldsProvider.tableListProvider = tablesListProvider;
     indexesProvider.tableListProvider = tablesListProvider;
 
-    const groupListProvider = new GroupListProvider(context, tables);
+    const groupListProvider = new GroupListProvider(
+        context,
+        tablesListProvider,
+        favoritesProvider,
+        customViewsProvider
+    );
     const groups = vscode.window.createTreeView(
         `${Constants.globalExtensionKey}-databases`,
         { treeDataProvider: groupListProvider, canSelectMany: true },
@@ -324,12 +329,7 @@ export async function activate(context: vscode.ExtensionContext) {
     );
 
     groups.onDidChangeSelection((e) =>
-        groupListProvider.onDidChangeSelection(
-            e,
-            tablesListProvider,
-            favoritesProvider,
-            customViewsProvider,
-        ),
+        groupListProvider.onDidChangeSelection(e),
     );
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,6 +292,7 @@ export async function activate(context: vscode.ExtensionContext) {
         context,
         groupListProvider
     );
+    
     groupListProvider.setProviders(
         tablesListProvider,
         favoritesProvider,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -398,8 +398,9 @@ export async function activate(context: vscode.ExtensionContext) {
                 nodeList = tablesListProvider.tableNodes;
         }
 
+        const targetFullName = node.getFullName(true);
         const newNode = nodeList.find(
-            (correctNode) => node.tableName === correctNode.tableName,
+            (correctNode) => correctNode.getFullName(true) === targetFullName,
         );
 
         if (newNode) {

--- a/src/providers/AblHoverProvider.ts
+++ b/src/providers/AblHoverProvider.ts
@@ -31,7 +31,6 @@ export class AblHoverProvider implements HoverProvider {
                 .toLowerCase()
                 .indexOf(tableNode.tableName.toLowerCase());
             if (index >= 0) {
-                this.tableListProvider.selectDbConfig(tableNode);
                 this.tableListProvider.node = tableNode;
                 str.value =
                     '[Run Query for ' +

--- a/src/repo/utils/cache.ts
+++ b/src/repo/utils/cache.ts
@@ -19,7 +19,7 @@ export const getSelectedColumnsCache = (
     }
     return (
         Constants.context.globalState.get<string[]>(
-            `${CacheKeyNames.SelectedColumns}.${node.getFullName()}`
+            `${CacheKeyNames.SelectedColumns}.${node.getFullName(true)}`
         ) ?? []
     );
 };
@@ -37,7 +37,7 @@ export const updateSelectedColumnsCache = (
         return [];
     }
     Constants.context.globalState.update(
-        `${CacheKeyNames.SelectedColumns}.${node.getFullName()}`,
+        `${CacheKeyNames.SelectedColumns}.${node.getFullName(true)}`,
         newValueArr
     );
 };
@@ -53,7 +53,7 @@ export const getAllColumnsCache = (node: TableNode | undefined): string[] => {
     }
     return (
         Constants.context.globalState.get<string[]>(
-            `${CacheKeyNames.AllColumns}.${node.getFullName()}`
+            `${CacheKeyNames.AllColumns}.${node.getFullName(true)}`
         ) ?? []
     );
 };
@@ -71,7 +71,7 @@ export const updateAllColumnsCache = (
         return [];
     }
     Constants.context.globalState.update(
-        `${CacheKeyNames.AllColumns}.${node.getFullName()}`,
+        `${CacheKeyNames.AllColumns}.${node.getFullName(true)}`,
         newValueArr
     );
 };

--- a/src/treeview/CustomViewProvider.ts
+++ b/src/treeview/CustomViewProvider.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 import { TablesListProvider } from './TablesListProvider';
 import { TableNode, TableNodeSourceEnum } from './TableNode';
-import { IConfig, ICustomView } from '../view/app/model';
+import { ICustomView } from '../view/app/model';
 import { PanelViewProvider } from '../webview/PanelViewProvider';
 import { CustomViewNode } from './CustomViewNode';
 import { Constants } from '../common/Constants';
+import { GroupListProvider } from './GroupListProvider';
 
 export class CustomViewProvider extends TablesListProvider {
     public override node: CustomViewNode | undefined;
@@ -14,13 +15,13 @@ export class CustomViewProvider extends TablesListProvider {
     > = new vscode.EventEmitter<TableNode | undefined | void>();
     readonly onDidChangeTreeData: vscode.Event<TableNode | undefined | void> =
         this._onDidChangeTreeData.event;
-    public configs: IConfig[] | undefined;
     constructor(
         fieldProvider: PanelViewProvider,
         indexesProvider: PanelViewProvider,
-        context: vscode.ExtensionContext
+        context: vscode.ExtensionContext,
+        groupListProvider: GroupListProvider
     ) {
-        super(fieldProvider, indexesProvider, context);
+        super(fieldProvider, indexesProvider, context, groupListProvider);
     }
 
     /**
@@ -100,9 +101,9 @@ export class CustomViewProvider extends TablesListProvider {
                 customViewParams: ICustomView;
             }[]
         >('custom-views', []);
-        const filteredCustomViews = customViewData.filter((customView) =>
-            this.configs?.some((config) => config.id === customView.dbId)
-        );
+        const filteredCustomViews = customViewData.filter((customView) => {
+            return this.getLatestConfig(customView.dbId) !== undefined;
+        });
 
         const customViews = filteredCustomViews.map(
             (data) =>
@@ -156,11 +157,7 @@ export class CustomViewProvider extends TablesListProvider {
         );
     }
 
-    public refresh(configs: IConfig[] | undefined): void {
-        if (configs !== undefined) {
-            this.configs = configs;
-            this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
-        }
+    public refresh(): void {
         this._onDidChangeTreeData.fire();
     }
 }

--- a/src/treeview/CustomViewProvider.ts
+++ b/src/treeview/CustomViewProvider.ts
@@ -42,8 +42,8 @@ export class CustomViewProvider extends TablesListProvider {
     public async getChildren(
         element?: CustomViewNode
     ): Promise<CustomViewNode[]> {
-        if (!element) return this.getCustomViews();
-        else return [];
+        if (!element) {return this.getCustomViews();}
+        else {return [];}
     }
 
     saveCustomView(node: CustomViewNode): void {
@@ -159,6 +159,7 @@ export class CustomViewProvider extends TablesListProvider {
     public refresh(configs: IConfig[] | undefined): void {
         if (configs !== undefined) {
             this.configs = configs;
+            this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
         }
         this._onDidChangeTreeData.fire();
     }

--- a/src/treeview/CustomViewProvider.ts
+++ b/src/treeview/CustomViewProvider.ts
@@ -102,7 +102,10 @@ export class CustomViewProvider extends TablesListProvider {
             }[]
         >('custom-views', []);
         const filteredCustomViews = customViewData.filter((customView) => {
-            return this.getLatestConfig(customView.dbId) !== undefined;
+            return (
+                this.getLatestConfig(customView.dbId) !== undefined &&
+                this.isDbIdSelected(customView.dbId)
+            );
         });
 
         const customViews = filteredCustomViews.map(

--- a/src/treeview/FavoritesProvider.ts
+++ b/src/treeview/FavoritesProvider.ts
@@ -54,7 +54,10 @@ export class FavoritesProvider extends TablesListProvider {
         >('favorites', []);
 
         const filteredFavorites = favoritesData.filter((favorite) => {
-            return this.getLatestConfig(favorite.dbId) !== undefined;
+            return (
+                this.getLatestConfig(favorite.dbId) !== undefined &&
+                this.isDbIdSelected(favorite.dbId)
+            );
         });
 
         const favorites = filteredFavorites.map(

--- a/src/treeview/FavoritesProvider.ts
+++ b/src/treeview/FavoritesProvider.ts
@@ -149,6 +149,7 @@ export class FavoritesProvider extends TablesListProvider {
     public refresh(configs: IConfig[] | undefined): void {
         if (configs !== undefined) {
             this.configs = configs;
+            this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
         }
         this._onDidChangeTreeData.fire();
     }

--- a/src/treeview/FavoritesProvider.ts
+++ b/src/treeview/FavoritesProvider.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import { TableNode, TableNodeSourceEnum } from './TableNode';
 import { TablesListProvider } from './TablesListProvider';
+import { GroupListProvider } from './GroupListProvider';
 import { PanelViewProvider } from '../webview/PanelViewProvider';
-import { IConfig } from '../view/app/model';
 import { Constants } from '../common/Constants';
 
 export class FavoritesProvider extends TablesListProvider {
@@ -11,14 +11,14 @@ export class FavoritesProvider extends TablesListProvider {
     > = new vscode.EventEmitter<TableNode | undefined | void>();
     readonly onDidChangeTreeData: vscode.Event<TableNode | undefined | void> =
         this._onDidChangeTreeData.event;
-    public configs: IConfig[] | undefined;
 
     constructor(
         fieldsProvider: PanelViewProvider,
         indexesProvider: PanelViewProvider,
-        context: vscode.ExtensionContext
+        context: vscode.ExtensionContext,
+        groupListProvider: GroupListProvider
     ) {
-        super(fieldsProvider, indexesProvider, context);
+        super(fieldsProvider, indexesProvider, context, groupListProvider);
     }
 
     /**
@@ -53,9 +53,9 @@ export class FavoritesProvider extends TablesListProvider {
             }[]
         >('favorites', []);
 
-        const filteredFavorites = favoritesData.filter((favorite) =>
-            this.configs?.some((config) => config.id === favorite.dbId)
-        );
+        const filteredFavorites = favoritesData.filter((favorite) => {
+            return this.getLatestConfig(favorite.dbId) !== undefined;
+        });
 
         const favorites = filteredFavorites.map(
             (data) =>
@@ -146,11 +146,7 @@ export class FavoritesProvider extends TablesListProvider {
         }
     }
 
-    public refresh(configs: IConfig[] | undefined): void {
-        if (configs !== undefined) {
-            this.configs = configs;
-            this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
-        }
+    public refresh(): void {
         this._onDidChangeTreeData.fire();
     }
 }

--- a/src/treeview/GroupListProvider.ts
+++ b/src/treeview/GroupListProvider.ts
@@ -10,32 +10,33 @@ import { FavoritesProvider } from './FavoritesProvider';
 import { CustomViewProvider } from './CustomViewProvider';
 
 export class GroupListProvider
-    implements vscode.TreeDataProvider<INode>, IRefreshCallback
+implements vscode.TreeDataProvider<INode>, IRefreshCallback
 {
     private _onDidChangeTreeData: vscode.EventEmitter<
         INode | undefined | void
     > = new vscode.EventEmitter<INode | undefined | void>();
     readonly onDidChangeTreeData: vscode.Event<INode | undefined | void> =
         this._onDidChangeTreeData.event;
+    private tablesProvider: TablesListProvider | undefined;
+    private favoritesProvider: FavoritesProvider | undefined;
+    private customViewsProvider: CustomViewProvider | undefined;
 
     constructor(
         private context: vscode.ExtensionContext,
-        private tables: vscode.TreeView<INode>
-    ) {}
+        private tables: TablesListProvider,
+        private favorites: FavoritesProvider,
+        private customViews: CustomViewProvider
+    ) {
+        this.tablesProvider = tables;
+        this.favoritesProvider = favorites;
+        this.customViewsProvider = customViews;
+    }
 
     onDidChangeSelection(
-        e: vscode.TreeViewSelectionChangeEvent<INode>,
-        tablesListProvider: vscode.TreeDataProvider<INode>,
-        favoritesProvider: vscode.TreeDataProvider<INode>,
-        customViewsProvider: vscode.TreeDataProvider<INode>
+        e: vscode.TreeViewSelectionChangeEvent<INode>
     ): any {
         if (e.selection.length) {
-            if (
-                e.selection[0] instanceof DbConnectionNode &&
-                tablesListProvider instanceof TablesListProvider &&
-                favoritesProvider instanceof FavoritesProvider &&
-                customViewsProvider instanceof CustomViewProvider
-            ) {
+            if (e.selection[0] instanceof DbConnectionNode) {
                 const nodes = e.selection as DbConnectionNode[];
                 const configs: IConfig[] = [];
 
@@ -44,15 +45,15 @@ export class GroupListProvider
                 });
 
                 console.log('GroupList', configs);
-                tablesListProvider.refresh(configs);
-                favoritesProvider.refresh(configs);
-                customViewsProvider.refresh(configs);
+                this.tablesProvider?.refresh(configs);
+                this.favoritesProvider?.refresh(configs);
+                this.customViewsProvider?.refresh(configs);
                 return;
             }
         }
-        (tablesListProvider as TablesListProvider).refresh(undefined);
-        (favoritesProvider as FavoritesProvider).refresh(undefined);
-        (customViewsProvider as CustomViewProvider).refresh(undefined);
+        this.tablesProvider?.refresh(undefined);
+        this.favoritesProvider?.refresh(undefined);
+        this.customViewsProvider?.refresh(undefined);
     }
 
     refresh(): void {
@@ -70,6 +71,16 @@ export class GroupListProvider
             return this.getGroupNodes();
         }
         return element.getChildren();
+    }
+
+    updateProviders( configs: IConfig[] | undefined): void {
+        const tablesProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.tablesProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
+        const favoritesProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.favoritesProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
+        const customViewsProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.customViewsProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
+
+        this.tablesProvider?.refresh(tablesProviderConfigs);
+        this.favoritesProvider?.refresh(favoritesProviderConfigs);
+        this.customViewsProvider?.refresh(customViewsProviderConfigs);
     }
 
     private async getGroupNodes(): Promise<groupNode.GroupNode[]> {
@@ -112,6 +123,10 @@ export class GroupListProvider
                 }
             }
         }
+
+        this.updateProviders([...Object.values(connections || {}), 
+            ...Object.values(workspaceConnections || {})]);
+
         return groupNodes;
     }
 }

--- a/src/treeview/GroupListProvider.ts
+++ b/src/treeview/GroupListProvider.ts
@@ -3,11 +3,11 @@ import { Constants } from '../common/Constants';
 import { INode } from './INode';
 import * as groupNode from './GroupNode';
 import { IConfig } from '../view/app/model';
-import { TablesListProvider } from './TablesListProvider';
-import { DbConnectionNode } from './DbConnectionNode';
 import { IRefreshCallback } from './IRefreshCallback';
+import { TablesListProvider } from './TablesListProvider';
 import { FavoritesProvider } from './FavoritesProvider';
 import { CustomViewProvider } from './CustomViewProvider';
+import { DbConnectionNode } from './DbConnectionNode';
 
 export class GroupListProvider
 implements vscode.TreeDataProvider<INode>, IRefreshCallback
@@ -20,40 +20,63 @@ implements vscode.TreeDataProvider<INode>, IRefreshCallback
     private tablesProvider: TablesListProvider | undefined;
     private favoritesProvider: FavoritesProvider | undefined;
     private customViewsProvider: CustomViewProvider | undefined;
-
+    private selectedConfigs: IConfig[] = [];
+    
     constructor(
-        private context: vscode.ExtensionContext,
-        private tables: TablesListProvider,
-        private favorites: FavoritesProvider,
-        private customViews: CustomViewProvider
+        private context: vscode.ExtensionContext
     ) {
-        this.tablesProvider = tables;
-        this.favoritesProvider = favorites;
-        this.customViewsProvider = customViews;
     }
 
-    onDidChangeSelection(
+    public setProviders(
+        tablesProvider: TablesListProvider,
+        favoritesProvider: FavoritesProvider,
+        customViewsProvider: CustomViewProvider
+    ): void {
+        this.tablesProvider = tablesProvider;
+        this.favoritesProvider = favoritesProvider;
+        this.customViewsProvider = customViewsProvider;
+    }
+
+    public async onDidChangeSelection(
         e: vscode.TreeViewSelectionChangeEvent<INode>
-    ): any {
-        if (e.selection.length) {
-            if (e.selection[0] instanceof DbConnectionNode) {
-                const nodes = e.selection as DbConnectionNode[];
-                const configs: IConfig[] = [];
+    ): Promise<void> {
+        if (!e.selection.length) {
+            this.selectedConfigs = [];
+            return;
+        }
 
-                nodes.forEach((node) => {
-                    configs.push(node.config);
+        const configs: IConfig[] = [];
+
+        for (const selected of e.selection) {
+            if (selected instanceof DbConnectionNode) {
+                configs.push(selected.config);
+                continue;
+            }
+
+            if (selected instanceof groupNode.GroupNode) {
+                const children = await selected.getChildren();
+                children.forEach((child) => {
+                    if (child instanceof DbConnectionNode) {
+                        configs.push(child.config);
+                    }
                 });
-
-                console.log('GroupList', configs);
-                this.tablesProvider?.refresh(configs);
-                this.favoritesProvider?.refresh(configs);
-                this.customViewsProvider?.refresh(configs);
-                return;
             }
         }
-        this.tablesProvider?.refresh(undefined);
-        this.favoritesProvider?.refresh(undefined);
-        this.customViewsProvider?.refresh(undefined);
+
+        if (!configs.length) {
+            this.selectedConfigs = [];
+            return;
+        }
+
+        this.selectedConfigs = configs;
+
+        this.tablesProvider?.refresh();
+        this.favoritesProvider?.refresh();
+        this.customViewsProvider?.refresh();
+    }
+
+    public getSelectedConfigs(): IConfig[] {
+        return this.selectedConfigs;
     }
 
     refresh(): void {
@@ -71,16 +94,6 @@ implements vscode.TreeDataProvider<INode>, IRefreshCallback
             return this.getGroupNodes();
         }
         return element.getChildren();
-    }
-
-    updateProviders( configs: IConfig[] | undefined): void {
-        const tablesProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.tablesProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
-        const favoritesProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.favoritesProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
-        const customViewsProviderConfigs: IConfig[] | undefined = configs?.filter((config) => this.customViewsProvider?.tableNodes.map((node) => node.dbId).includes(config.id));
-
-        this.tablesProvider?.refresh(tablesProviderConfigs);
-        this.favoritesProvider?.refresh(favoritesProviderConfigs);
-        this.customViewsProvider?.refresh(customViewsProviderConfigs);
     }
 
     private async getGroupNodes(): Promise<groupNode.GroupNode[]> {
@@ -124,9 +137,35 @@ implements vscode.TreeDataProvider<INode>, IRefreshCallback
             }
         }
 
-        this.updateProviders([...Object.values(connections || {}), 
-            ...Object.values(workspaceConnections || {})]);
-
         return groupNodes;
+    }
+
+    public getConfigByGroup(group: string): IConfig | undefined {
+        const connections = this.context.globalState.get<{
+            [key: string]: IConfig;
+        }>(`${Constants.globalExtensionKey}.dbconfig`);
+
+        if (connections) {
+            // return config if available
+            const config = Object.values(connections).find((config) => config.id.toUpperCase() === group.toUpperCase());
+            if (config) {
+                return config;
+            }
+        }
+
+        const workspaceConnections = this.context.workspaceState.get<{
+            [key: string]: IConfig;
+        }>(`${Constants.globalExtensionKey}.dbconfig`);
+
+        if (workspaceConnections) {
+            // return config if available
+            const config = Object.values(workspaceConnections).find((config) => config.id.toUpperCase() === group.toUpperCase());
+            if (config) {
+                return config;
+            }
+        }
+
+        console.warn(`No configuration found for group: ${group}`);
+        return undefined;
     }
 }

--- a/src/treeview/TablesListProvider.ts
+++ b/src/treeview/TablesListProvider.ts
@@ -11,21 +11,23 @@ import {
     updateAllColumnsCache,
 } from '../repo/utils/cache';
 import { Constants } from '../common/Constants';
+import { GroupListProvider } from './GroupListProvider';
 
 export class TablesListProvider implements vscode.TreeDataProvider<INode> {
-    public config: IConfig | undefined;
-    public configs: IConfig[] | undefined;
-    public node: TableNode | undefined;
-    public tableNodes: tableNode.TableNode[] = [];
-    public filters: string[] | undefined = ['UserTable'];
-    public tableClicked: TableCount = { tableName: undefined, count: 0 };
+    public  node: TableNode | undefined;
+    public  tableNodes: tableNode.TableNode[] = [];
+    public  filters: string[] | undefined = ['UserTable'];
+    public  tableClicked: TableCount = { tableName: undefined, count: 0 };
+    public  groupList: GroupListProvider | undefined;
 
     constructor(
         public fieldsProvider: PanelViewProvider,
         public indexesProvider: PanelViewProvider,
-        public context: vscode.ExtensionContext
+        public context: vscode.ExtensionContext,
+        public groupListProvider: GroupListProvider
     ) {
         this.context = context;
+        this.groupList = groupListProvider;
     }
 
     public displayData(node: TableNode, useCache = true) {
@@ -44,7 +46,7 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
             });
         } else {
             return ProcessorFactory.getProcessorInstance()
-                .getTableDetails(this.config, node.tableName)
+                .getTableDetails(this.getLatestConfig(node.dbId), node.tableName)
                 .then((oeTableDetails) => {
                     const previouslySelectedColumns = getSelectedColumnsCache(
                         this.node
@@ -110,20 +112,11 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
     }
 
     onDidChangeSelection(e: vscode.TreeViewSelectionChangeEvent<INode>): void {
-        if (e.selection.length && this.configs) {
+        if (e.selection.length) {
             if (e.selection[0] instanceof TableNode) {
                 this.node = e.selection[0];
-                this.selectDbConfig(this.node);
                 this.displayData(this.node, false);
             }
-        }
-    }
-
-    public selectDbConfig(node: TableNode) {
-        if (this.configs) {
-            this.config = this.configs.find(
-                (config) => config.name === node.connectionName
-            );
         }
     }
 
@@ -155,9 +148,7 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
         }, 500);
     }
 
-    public refresh(configs: IConfig[] | undefined): void {
-        this.configs = configs;
-        this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
+    public refresh(): void {
         this._onDidChangeTreeData.fire();
     }
 
@@ -180,59 +171,56 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
         return element.getChildren();
     }
 
-    private async getGroupNodes(): Promise<void> {
+    private async getGroupNode(): Promise<void> {
         this.tableNodes = [];
-        if (this.configs) {
-            for (const config of this.configs) {
-                await ProcessorFactory.getProcessorInstance()
-                    .getTablesList(config)
-                    .then((oeTables) => {
-                        if (oeTables instanceof Error) {
-                            return;
-                        }
+        const configsToLoad = this.groupList?.getSelectedConfigs() ?? [];
 
-                        if (oeTables.error) {
-                            vscode.window.showErrorMessage(
-                                `Error connecting DB: ${oeTables.description} (${oeTables.error})`
-                            );
-                            return;
-                        }
+        for (const config of configsToLoad) {
+            await ProcessorFactory.getProcessorInstance()
+                .getTablesList(config)
+                .then((oeTables) => {
+                    if (oeTables instanceof Error) {
+                        return;
+                    }
 
-                        if (config) {
-                            console.log(
-                                `Requested tables list of DB: ${config.name}`
-                            );
-                            const connectionLabel = config.label;
-                            const connectionName = config.name;
-                            oeTables.tables.forEach(
-                                (table: {
-                                    name: string;
-                                    tableType: string;
-                                }) => {
-                                    this.tableNodes?.push(
-                                        new tableNode.TableNode(
-                                            Constants.context,
-                                            config.id,
-                                            table.name,
-                                            table.tableType,
-                                            connectionName,
-                                            connectionLabel,
-                                            TableNodeSourceEnum.Tables
-                                        )
-                                    );
-                                }
+                    if (oeTables.error) {
+                        vscode.window.showErrorMessage(
+                            `Error connecting DB: ${oeTables.description} (${oeTables.error})`
+                        );
+                        return;
+                    }
+
+                    console.log(`Requested tables list of DB: ${config.name}`);
+                    const connectionLabel = config.label;
+                    const connectionName = config.name;
+                    oeTables.tables.forEach(
+                        (table: { name: string; tableType: string }) => {
+                            this.tableNodes?.push(
+                                new tableNode.TableNode(
+                                    Constants.context,
+                                    config.id,
+                                    table.name,
+                                    table.tableType,
+                                    connectionName,
+                                    connectionLabel,
+                                    TableNodeSourceEnum.Tables
+                                )
                             );
                         }
-                    });
-            }
+                    );
+                });
         }
     }
 
     public async getFilteredTables(): Promise<tableNode.TableNode[]> {
-        await this.getGroupNodes();
+        await this.getGroupNode();
 
         return this.tableNodes.filter((table) => {
             return this.filters?.includes(table.tableType);
         });
+    }
+
+    public getLatestConfig(groupId: string): IConfig | undefined {
+        return this.groupList?.getConfigByGroup(groupId);
     }
 }

--- a/src/treeview/TablesListProvider.ts
+++ b/src/treeview/TablesListProvider.ts
@@ -157,6 +157,7 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
 
     public refresh(configs: IConfig[] | undefined): void {
         this.configs = configs;
+        this.config  = configs?.filter((config) => this.tableNodes.map((node) => node.dbId).includes(config.id))[0];
         this._onDidChangeTreeData.fire();
     }
 
@@ -173,6 +174,7 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
 
     public getChildren(element?: INode): Thenable<INode[]> | INode[] {
         if (!element) {
+            console.log('Load up the tree!');
             return this.getFilteredTables();
         }
         return element.getChildren();

--- a/src/treeview/TablesListProvider.ts
+++ b/src/treeview/TablesListProvider.ts
@@ -223,4 +223,8 @@ export class TablesListProvider implements vscode.TreeDataProvider<INode> {
     public getLatestConfig(groupId: string): IConfig | undefined {
         return this.groupList?.getConfigByGroup(groupId);
     }
+
+    protected isDbIdSelected(dbId: string): boolean {
+        return this.groupList?.getSelectedConfigs().some((config) => config.id === dbId) ?? false;
+    }
 }

--- a/src/webview/QueryEditor.ts
+++ b/src/webview/QueryEditor.ts
@@ -336,11 +336,11 @@ export class QueryEditor {
     public fetchConfig = (tableNodeSource: string): IConfig | undefined => {
         switch (tableNodeSource) {
             case TableNodeSourceEnum.Tables:
-                return this.tableListProvider.config;
+                return this.tableListProvider.getLatestConfig(this.tableNode.dbId);
             case TableNodeSourceEnum.Favorites:
-                return this.favoritesProvider.config;
+                return this.favoritesProvider.getLatestConfig(this.tableNode.dbId);
             case TableNodeSourceEnum.Custom:
-                return this.customViewProvider.config;
+                return this.customViewProvider.getLatestConfig(this.tableNode.dbId);
             default:
                 return undefined;
         }

--- a/src/webview/QueryEditor.ts
+++ b/src/webview/QueryEditor.ts
@@ -47,21 +47,8 @@ export class QueryEditor {
         this.tableName = tableNode.tableName;
         this.fieldsProvider = fieldProvider;
 
-        let config: IConfig | undefined;
-        switch (this.tableNode.source) {
-        case TableNodeSourceEnum.Tables:
-            config = this.tableListProvider.config;
-            break;
-        case TableNodeSourceEnum.Favorites:
-            config = this.favoritesProvider.config;
-            break;
-        case TableNodeSourceEnum.Custom:
-            config = this.customViewProvider.config;
-            break;
-        default:
-            return;
-        }
-
+        const config: IConfig | undefined = this.fetchConfig(this.tableNode.source);
+ 
         if (tableNode instanceof CustomViewNode) {
             this.customViewData = tableNode.customViewParams;
         }
@@ -113,50 +100,115 @@ export class QueryEditor {
 
         this.panel.webview.onDidReceiveMessage(
             (command: ICommand) => {
+                // config can change if user updates connection parameters
+                const config: IConfig | undefined = this.fetchConfig(this.tableNode.source);
                 this.logger.log('command:', command);
                 switch (command.action) {
-                case CommandAction.Query:
-                    if (config) {
-                        ProcessorFactory.getProcessorInstance()
-                            .getTableData(
-                                config,
-                                this.tableNode.tableName,
-                                this.customViewData
-                                    ? this.getParams(command.params!)
-                                    : command.params
-                            )
-                            .then((oe) => {
-                                if (this.customViewData) {
-                                    const obj = {
-                                        id: command.id,
-                                        command: 'customViewParams',
-                                        params: this.customViewData,
-                                    };
-                                    this.logger.log(
-                                        'customView params: ',
-                                        this.customViewData
-                                    );
-                                    this.panel?.webview.postMessage(obj);
-                                }
+                    case CommandAction.Query:
+                        if (config) {
+                            ProcessorFactory.getProcessorInstance()
+                                .getTableData(
+                                    config,
+                                    this.tableNode.tableName,
+                                    this.customViewData
+                                        ? this.getParams(command.params!)
+                                        : command.params
+                                )
+                                .then((oe) => {
+                                    if (this.customViewData) {
+                                        const obj = {
+                                            id: command.id,
+                                            command: 'customViewParams',
+                                            params: this.customViewData,
+                                        };
+                                        this.logger.log(
+                                            'customView params: ',
+                                            this.customViewData
+                                        );
+                                        this.panel?.webview.postMessage(obj);
+                                    }
  
-                                if (this.panel) {
-                                    const obj = {
-                                        id: command.id,
-                                        command: 'data',
-                                        columns:
+                                    if (this.panel) {
+                                        const obj = {
+                                            id: command.id,
+                                            command: 'data',
+                                            columns:
                                                 tableNode.cache
                                                     ?.selectedColumns,
-                                        data: oe,
-                                    };
-                                    this.logger.log('data:', obj);
-                                    this.customViewData = undefined;
-                                    this.panel?.webview.postMessage(obj);
-                                }
-                            });
-                    }
-                    break;
-                case CommandAction.CRUD:
-                    if (config) {
+                                            data: oe,
+                                        };
+                                        this.logger.log('data:', obj);
+                                        this.customViewData = undefined;
+                                        this.panel?.webview.postMessage(obj);
+                                    }
+                                });
+                        }
+                        break;
+                    case CommandAction.CRUD:
+                        if (config) {
+                            ProcessorFactory.getProcessorInstance()
+                                .getTableData(
+                                    config,
+                                    this.tableNode.tableName,
+                                    command.params
+                                )
+                                .then((oe) => {
+                                    if (this.panel) {
+                                        const obj = {
+                                            id: command.id,
+                                            command: 'crud',
+                                            data: oe,
+                                        };
+                                        this.logger.log('data:', obj);
+                                        this.panel?.webview.postMessage(obj);
+                                    }
+                                });
+                        }
+                        break;
+                    case CommandAction.Submit:
+                        if (config) {
+                            ProcessorFactory.getProcessorInstance()
+                                .submitTableData(
+                                    config,
+                                    this.tableNode.tableName,
+                                    command.params
+                                )
+                                .then((oe) => {
+                                    if (this.panel) {
+                                        const obj = {
+                                            id: command.id,
+                                            command: 'submit',
+                                            data: oe,
+                                        };
+                                        this.logger.log('data:', obj);
+                                        if (
+                                            obj.data.description !== null &&
+                                            obj.data.description !== undefined
+                                        ) {
+                                            if (obj.data.description === '') {
+                                                vscode.window.showErrorMessage(
+                                                    'Database Error: Trigger canceled action'
+                                                );
+                                            } else {
+                                                vscode.window.showErrorMessage(
+                                                    'Database Error: ' +
+                                                        obj.data.description
+                                                );
+                                            }
+                                        } else {
+                                            vscode.window.showInformationMessage(
+                                                'Action was successful'
+                                            );
+                                        }
+                                        this.panel?.webview.postMessage(obj);
+                                    }
+                                });
+                        }
+                        break;
+                    case CommandAction.Export:
+                        if (!config) {
+                            break;
+                        }
                         ProcessorFactory.getProcessorInstance()
                             .getTableData(
                                 config,
@@ -164,128 +216,65 @@ export class QueryEditor {
                                 command.params
                             )
                             .then((oe) => {
-                                if (this.panel) {
-                                    const obj = {
-                                        id: command.id,
-                                        command: 'crud',
-                                        data: oe,
-                                    };
-                                    this.logger.log('data:', obj);
-                                    this.panel?.webview.postMessage(obj);
+                                if (!this.panel) {
+                                    return;
                                 }
-                            });
-                    }
-                    break;
-                case CommandAction.Submit:
-                    if (config) {
-                        ProcessorFactory.getProcessorInstance()
-                            .submitTableData(
-                                config,
-                                this.tableNode.tableName,
-                                command.params
-                            )
-                            .then((oe) => {
-                                if (this.panel) {
-                                    const obj = {
-                                        id: command.id,
-                                        command: 'submit',
-                                        data: oe,
-                                    };
-                                    this.logger.log('data:', obj);
-                                    if (
-                                        obj.data.description !== null &&
-                                            obj.data.description !== undefined
-                                    ) {
-                                        if (obj.data.description === '') {
-                                            vscode.window.showErrorMessage(
-                                                'Database Error: Trigger canceled action'
-                                            );
-                                        } else {
-                                            vscode.window.showErrorMessage(
-                                                'Database Error: ' +
-                                                        obj.data.description
-                                            );
-                                        }
-                                    } else {
-                                        vscode.window.showInformationMessage(
-                                            'Action was successful'
-                                        );
-                                    }
-                                    this.panel?.webview.postMessage(obj);
+                                if (!config) {
+                                    throw new Error(
+                                        'Configuration became undefined unexpectedly.'
+                                    );
                                 }
-                            });
-                    }
-                    break;
-                case CommandAction.Export:
-                    if (!config) {
-                        break;
-                    }
-                    ProcessorFactory.getProcessorInstance()
-                        .getTableData(
-                            config,
-                            this.tableNode.tableName,
-                            command.params
-                        )
-                        .then((oe) => {
-                            if (!this.panel) {
-                                return;
-                            }
-                            if (!config) {
-                                throw new Error(
-                                    'Configuration became undefined unexpectedly.'
-                                );
-                            }
-                            let exportData = oe;
-                            if (command.params?.exportType === 'dumpFile') {
-                                const dumpFileFormatter =
+                                let exportData = oe;
+                                if (command.params?.exportType === 'dumpFile') {
+                                    const dumpFileFormatter =
                                         new DumpFileFormatter();
-                                dumpFileFormatter.formatDumpFile(
-                                    oe,
-                                    this.tableNode.tableName,
-                                    config.label
-                                );
-                                exportData =
+                                    dumpFileFormatter.formatDumpFile(
+                                        oe,
+                                        this.tableNode.tableName,
+                                        config.label
+                                    );
+                                    exportData =
                                         dumpFileFormatter.getDumpFile();
-                            }
-                            if (command.params !== undefined) {
-                                const obj = {
-                                    id: command.id,
-                                    command: 'export',
-                                    tableName: this.tableNode.tableName,
-                                    data: exportData,
-                                    format: command.params.exportType,
-                                };
+                                }
+                                if (command.params !== undefined) {
+                                    const obj = {
+                                        id: command.id,
+                                        command: 'export',
+                                        tableName: this.tableNode.tableName,
+                                        data: exportData,
+                                        format: command.params.exportType,
+                                    };
 
-                                this.logger.log('data:', obj);
-                                this.panel?.webview.postMessage(obj);
-                            }
-                        });
-                    break;
-                case CommandAction.SaveCustomQuery:
-                    vscode.commands
-                        .executeCommand(
-                            `${Constants.globalExtensionKey}.saveCustomView`,
-                            new CustomViewNode(
-                                Constants.context,
-                                this.tableNode,
-                                command.customView?.name || '',
-                                command.customView
+                                    this.logger.log('data:', obj);
+                                    this.panel?.webview.postMessage(obj);
+                                }
+                            });
+                        break;
+                    case CommandAction.SaveCustomQuery:
+                        vscode.commands
+                            .executeCommand(
+                                `${Constants.globalExtensionKey}.saveCustomView`,
+                                new CustomViewNode(
+                                    Constants.context,
+                                    this.tableNode,
+                                    command.customView?.name || '',
+                                    command.customView
+                                )
                             )
-                        )
-                        .then(
-                            () => {
-                                console.log(
-                                    'Command executed successfully'
-                                );
-                            },
-                            (error) => {
-                                console.error(
-                                    'Error executing command:',
-                                    error
-                                );
-                            }
-                        );
-                    break;
+                            .then(
+                                () => {
+                                    console.log(
+                                        'Command executed successfully'
+                                    );
+                                },
+                                (error) => {
+                                    console.error(
+                                        'Error executing command:',
+                                        error
+                                    );
+                                }
+                            );
+                        break;
                 }
             },
             undefined,
@@ -342,6 +331,19 @@ export class QueryEditor {
         };
         this.logger.log('refetch:', obj);
         this.panel?.webview.postMessage(obj);
+    };
+
+    public fetchConfig = (tableNodeSource: string): IConfig | undefined => {
+        switch (tableNodeSource) {
+            case TableNodeSourceEnum.Tables:
+                return this.tableListProvider.config;
+            case TableNodeSourceEnum.Favorites:
+                return this.favoritesProvider.config;
+            case TableNodeSourceEnum.Custom:
+                return this.customViewProvider.config;
+            default:
+                return undefined;
+        }
     };
 
     public updateFields() {


### PR DESCRIPTION
## Fix #609: Fetch Latest Database Configurations Dynamically in Query Editor

Used Google Gemini AI to write the below.

### Problem

Previously, the Query Editor stored a cached database configuration available at the time of its creation and would not receive updates if a user subsequently modified connection parameters. 

Attempting to resolve this via the sidebar views (TablesListProvider, CustomViewProvider, or FavoritesProvider) was insufficient because they also held stale, cached configurations that only refreshed upon manual database group re-selection.

---

### Solution

Refactored configuration management to eliminate stale caching entirely. Instead of propagating snapshot-in-time config objects down to individual sidebar views, providers now query a single source of truth dynamically from the underlying extension state.

* Centralized Configuration Lookup: Added getConfigByGroup(groupId) to GroupListProvider to retrieve live connection settings dynamically from VS Code's globalState or workspaceState storage on demand.
* Injected Provider References: Injected a reference of GroupListProvider directly into TablesListProvider, FavoritesProvider, and CustomViewProvider. These views now invoke getLatestConfig(dbId) dynamically rather than operating on a stale internal this.configs array.
* Dynamic Table Population: Updated TablesListProvider to query this.groupList.getSelectedConfigs() during its tree loading state (getGroupNode), ensuring it dynamically pulls tables for all actively highlighted database configurations managed by the GroupListProvider.
* Decoupled View Refreshing: Simplified tree view provider methods. Cleaned up .refresh() signatures so they no longer expect arrays of data passed as parameters.

---

### Codebase Changes Impact

#### src/treeview/
* GroupListProvider.ts: Implemented getConfigByGroup() to dynamically read active configurations from storage by group ID. Maintained selectedConfigs internally and triggered contextual view refreshes clean of parameter-passing bloat.
* TablesListProvider.ts: Replaced the local this.configs state cache with this.getLatestConfig(node.dbId) prior to invoking background processor data logic. Refactored getGroupNode() to fetch selected configs straight from the injected GroupListProvider.
* CustomViewProvider.ts & FavoritesProvider.ts: Cleaned out stale initialization loops. Replaced local .some() array iterations with active state evaluations using getLatestConfig(id) !== undefined.

#### src/ and src/webview/
* extension.ts: Streamlined extension activation orchestration. Properly passed the GroupListProvider context to secondary tree providers to establish a proper state dependency layout.
* QueryEditor.ts: Updated internal mechanics to dynamically query current config setups rather than relying on stale configuration captures from initialization.

---

### Test Coverage & Verification

Note: Verified functionality against mock data by monitoring DB Processor console messages to validate live configuration ingestion (no native OpenEdge environment required).

- [x] Live Parameter Updates (Open Editor): Modified connection properties while a Query Editor instance was active; verified it successfully processed requests using the updated configuration.
- [x] Live Parameter Updates (New Editor): Modified connection properties, opened a new Query Editor, and verified it initialized with new configurations.
- [x] Cross-Group Target Switching: Opened a Query Editor, selected an entirely different database group, and verified the previously opened editor still correctly targeted its original, non-selected database group.
- [x] Multi-Editor Isolation: Opened several Query Editors pointing to distinct database groups simultaneously; verified query routing integrity across all of them.
- [x] Multi-Group Selection Layout: Selected multiple database groups concurrently and verified the aggregate table list accurately combined all tables.
- [x] Custom View State Synchronization: Saved a custom view view, modified its base connection parameters, and verified updates propagated instantly to the view container.